### PR TITLE
[gha] Remove sha from concurrency group

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -21,7 +21,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.sha }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
After suggestion this was not accurate, retested, the prior stops I saw must have been unrelated due to originally trying to get that working.  I tried a 3 step process in testing to see the behavior where I had 3 separate builds trying to run.  Github will only stop the very prior build with same group so I had expected all and likely was pushing to fast during original testing before I thought I had it working.  I had done that testing with spotbugs maven plugin as it has a significantly large matrix at the time.

I did check to see if there was any way to get what I really wanted which is all prior to stop but that doesn't exist with github natively.  There is a 3rd party plugin that allows that by force but I don't think that is necessary on this repo.